### PR TITLE
Add sample PDF and parser extraction tests

### DIFF
--- a/tests/data/sample.pdf
+++ b/tests/data/sample.pdf
@@ -1,0 +1,52 @@
+%PDF-1.7
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Count 1/Kids[4 0 R]>>
+endobj
+
+3 0 obj
+<</Font<</helv 5 0 R>>>>
+endobj
+
+4 0 obj
+<</Type/Page/MediaBox[0 0 595 842]/Rotate 0/Resources 3 0 R/Parent 2 0 R/Contents[6 0 R]>>
+endobj
+
+5 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica/Encoding/WinAnsiEncoding>>
+endobj
+
+6 0 obj
+<</Length 70>>
+stream
+
+q
+BT
+1 0 0 1 72 770 Tm
+/helv 11 Tf [<48656c6c6f20576f726c64>]TJ
+ET
+Q
+
+endstream
+endobj
+
+xref
+0 7
+0000000000 65535 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000155 00000 n 
+0000000262 00000 n 
+0000000351 00000 n 
+
+trailer
+<</Size 7/Root 1 0 R/ID[<C3B572C29E5E503CC2B5C394C2B215C3><EB923C42B1635503123FBE323283A6D4>]>>
+startxref
+470
+%%EOF

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from pdf_parser import build_foundry_scenes
+from pdf_parser import build_foundry_scenes, extract_images, extract_text
 
 
 def test_build_foundry_scenes():
@@ -15,4 +15,17 @@ def test_build_foundry_scenes():
     assert scenes[0]["height"] == 200
     assert scenes[0]["grid"] == 75
     assert scenes[0]["gridType"] == 1
+
+
+def test_extract_images(tmp_path):
+    pdf = Path(__file__).parent / "data" / "sample.pdf"
+    images = extract_images(pdf, tmp_path)
+    assert len(images) == 0
+
+
+def test_extract_text():
+    pdf = Path(__file__).parent / "data" / "sample.pdf"
+    texts = extract_text(pdf)
+    assert len(texts) == 1
+    assert "Hello World" in texts[0]
 


### PR DESCRIPTION
## Summary
- add minimal `sample.pdf` for controlled parser testing
- extend tests to verify image extraction and page text output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c529a20ccc8329bff2a0b43e66c9f7