### PR TITLE
Add setup script for environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ builds minimal [Foundry VTT](https://foundryvtt.com/) scene definitions.
 
 ## Usage
 
-1. Install dependencies:
+1. Set up the Python environment:
    ```bash
-   pip install -r requirements.txt
+   ./scripts/setup_codex_env.sh
    ```
 2. Run the parser:
    ```bash

--- a/scripts/setup_codex_env.sh
+++ b/scripts/setup_codex_env.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+pip install -r requirements.txt
+pip install pytest pylint


### PR DESCRIPTION
## Summary
- add setup script to install runtime and development dependencies
- document how to use the setup script in the README

## Testing
- `./scripts/setup_codex_env.sh` *(fails: Could not find a version that satisfies the requirement pylint)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c52a4e50b08329836e7fb5ad3820b5