### PR TITLE
docs: expand master plan and contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+## Master Plan
+1. **Environment**
+   - Python ≥ 3.10, PyMuPDF
+   - End tests: pytest, pylint
+2. **Image Extraction & Labeling**
+   - Iterate pages of PF1e PDF, export every image.
+   - Deduplicate images via metadata (alt text, bookmarks); fallback `{page}_{index}`.
+   - Generate metadata file (bookmarks headings, page numbers) and labeling dictionary.
+3. **Foundry Compendium Generation (JournalEntry only)**
+   - Produce `module.json`; `"title"` derived from PDF filename and `"name"` from CLI or sanitized filename.
+   - Create a JournalEntry compendium (`packs/journal5e` or `.db`) containing one entry per labeled image.
+   - Each entry's image `src` uses `list[index].png` and metadata supplies hierarchy.
+   - Assign to nested folders when metadata supplies hierarchy.
+4. **CLI Enhancements**
+   - Flags: `--module-id`, `--title`, `--no-metadata`.
+   - Layout: main module entry followed by extracted image file reference.
+   - Environment variables override flags when present.
+5. **Testing & Validation**
+   - Unit tests: run CLI on a sample PDF and verify `module.json` and compendium content.
+   - Integration tests: run CLI on a sample PDF and verify folder hierarchy, module, and compendium.
+6. **Documentation & Project Guidance**
+   - Expanded `README` describing usage, tests, folder hierarchy, and Foundry import steps.
+   - Root `AGENTS.md` summarizing this master plan for contributors.
+
+## Development Guidelines
+- Write clear, well-documented Python code following PEP 8 style guidelines.
+- Include or update tests for any code changes and run `pytest` before committing.
+- Use conventional commit messages (e.g., `feat:`, `fix:`, `docs:`) and keep commits focused.
+
+## Hierarchy Expectations
+- The repository maintainer reviews and merges pull requests.
+- Open an issue or discussion before starting work on significant changes.
+- Contributors are expected to follow these guidelines and respect maintainers' decisions.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # PFone-2-PFtwo
 
-This repository contains a simple PDF parser that extracts embedded images and
-builds minimal [Foundry VTT](https://foundryvtt.com/) scene definitions.
+This repository contains a simple PDF parser that extracts embedded images and builds minimal [Foundry VTT](https://foundryvtt.com/) scene definitions.
 
 ## Usage
 
@@ -13,9 +12,10 @@ builds minimal [Foundry VTT](https://foundryvtt.com/) scene definitions.
    ```bash
    python pdf_parser.py path/to/file.pdf output_dir
    ```
-   This will save images into `output_dir` and create a `scenes.json` file with
-   basic scene definitions you can import into Foundry.
+   This will save images into `output_dir` and create a `scenes.json` file with basic scene definitions you can import into Foundry.
 
-The parser uses [PyMuPDF](https://pymupdf.readthedocs.io/) to extract images and
-can be extended with additional metadata or text extraction as needed.
+The parser uses [PyMuPDF](https://pymupdf.readthedocs.io/) to extract images and can be extended with additional metadata or text extraction as needed.
 
+## Contributing
+
+Before submitting changes, review [AGENTS.md](AGENTS.md) for the project's master plan, development guidelines, and hierarchy expectations.


### PR DESCRIPTION
## Summary
- document detailed master plan covering environment setup, image extraction, compendium generation, CLI flags, testing and docs guidance
- update README to direct contributors to AGENTS for onboarding and guidelines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c53b8365d88329830842002d848fdc