### PR TITLE
feat: label images via metadata and bookmarks

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -45,3 +45,41 @@ def test_extract_text():
     texts = extract_text(pdf)
     assert len(texts) == 1
     assert "Hello World" in texts[0]
+
+
+def _generate_pdf(path):
+    """Create a simple PDF with images, captions and bookmarks."""
+
+    import base64
+    import fitz
+
+    doc = fitz.open()
+    img_bytes = base64.b64decode(
+        b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PsLKFQAAAABJRU5ErkJggg=="
+    )
+    toc = []
+    for idx in range(2):
+        page = doc.new_page()
+        rect = fitz.Rect(20, 20, 120, 120)
+        page.insert_image(rect, stream=img_bytes)
+        page.insert_text(fitz.Point(20, 130), f"Label {idx + 1}")
+        toc.append([1, f"Section {idx + 1}", idx + 1])
+    doc.set_toc(toc)
+    doc.save(path)
+    return path
+
+
+def test_labels_and_hierarchy(tmp_path):
+    """Images derive names from captions and folders from bookmarks."""
+
+    pdf = _generate_pdf(tmp_path / "labeled.pdf")
+    out = tmp_path / "out"
+    images = extract_images(pdf, out)
+    assert images[0]["name"].startswith("label_1")
+    assert images[0]["folders"] == ["Section 1"]
+    assert images[1]["folders"] == ["Section 2"]
+
+    out2 = tmp_path / "out2"
+    images_nometa = extract_images(pdf, out2, use_metadata=False)
+    assert images_nometa[0]["name"].startswith("p1_img1")
+    assert images_nometa[0]["folders"] == []


### PR DESCRIPTION
## Summary
- derive image labels from metadata or nearby text
- build folder hierarchy from PDF bookmarks
- add `--no-metadata` flag to force fallback names

## Testing
- `pytest -q` *(skipped: fitz not installed)*
- `pylint pdf_parser.py tests/test_parser.py` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c53f655c988329915e391b640d450f