### PR TITLE
chore: enforce Python 3.10/3.11 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains a PDF parser that extracts embedded images and builds a [Foundry VTT](https://foundryvtt.com/) `JournalEntry` compendium.
 
+## Requirements
+
+- Python 3.10 or 3.11
+
 ## Usage
 
 1. Set up the Python environment:

--- a/scripts/setup_codex_env.sh
+++ b/scripts/setup_codex_env.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
+# Ensure an appropriate Python version is being used
+PYTHON_VERSION=$(python --version 2>&1)
+if ! python - <<'PY'
+import sys
+sys.exit(0 if sys.version_info[:2] in {(3, 10), (3, 11)} else 1)
+PY
+then
+  echo "Error: Python 3.10 or 3.11 is required. Current version: ${PYTHON_VERSION}" >&2
+  exit 1
+fi
+
 pip install -r requirements.txt
 pip install pytest pylint


### PR DESCRIPTION
## Summary
- add Python version guard to environment setup script
- document Python 3.10/3.11 requirement in README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement PyMuPDF>=1.23.0)*
- `pytest` *(passes: 1 skipped)*
- `pylint pdf_parser.py` *(fails: command not found: pylint)*

------
https://chatgpt.com/codex/tasks/task_e_68c5461370108329ba4d262035987bb9