### PR TITLE
feat: add optional scene tags and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ This repository contains a PDF parser that extracts embedded images and builds a
    ```
    Images are written to `output_dir`, and the directory will contain a `module.json` manifest and a `packs/images.json` compendium file ready for import into Foundry VTT.
 
-The parser uses [PyMuPDF](https://pymupdf.readthedocs.io/) to extract images, deduplicates them using PDF metadata, and can be extended with additional processing as needed.
+The parser uses [PyMuPDF](https://pymupdf.readthedocs.io/) to extract images, deduplicates them using PDF metadata, and can be extended with additional processing as needed. Optional flags provide extra metadata for the generated scenes:
+
+- `--tags-from-text` – include page text and bookmarks as tags on each scene.
+- `--note "Some note"` – attach a note to every generated scene.
+
+Example:
+
+```bash
+python pdf_parser.py file.pdf out --tags-from-text --note "GM only"
+```
 
 ## Labeling and Folder Hierarchy
 
@@ -64,6 +73,25 @@ The parser uses [PyMuPDF](https://pymupdf.readthedocs.io/) to extract images, de
     ]
   }
 ]
+```
+
+`scenes.json`
+
+```json
+{
+  "scenes": [
+    {
+      "name": "map.png",
+      "img": "maps/map.png",
+      "width": 100,
+      "height": 200,
+      "grid": 75,
+      "gridType": 1,
+      "tags": ["dungeon", "map"],
+      "notes": "GM only"
+    }
+  ]
+}
 ```
 
 ## Importing into Foundry VTT v13

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -27,15 +27,29 @@ from pdf_parser import (  # pylint: disable=wrong-import-position
 
 
 def test_build_foundry_scenes():
-    """Verify scenes include image metadata and grid size."""
-    images = [{"name": "map.png", "path": "maps/map.png", "width": 100, "height": 200}]
-    scenes = build_foundry_scenes(images, grid_size=75)
-    assert scenes[0]["name"] == "map.png"
-    assert scenes[0]["img"] == "maps/map.png"
-    assert scenes[0]["width"] == 100
-    assert scenes[0]["height"] == 200
-    assert scenes[0]["grid"] == 75
-    assert scenes[0]["gridType"] == 1
+    """Verify scenes include image metadata, tags and notes."""
+    images = [
+        {
+            "name": "map.png",
+            "path": "maps/map.png",
+            "width": 100,
+            "height": 200,
+            "text": "Dungeon Map",
+            "folders": ["Dungeon"],
+        }
+    ]
+    scenes = build_foundry_scenes(
+        images, grid_size=75, tags_from_text=True, note="Check traps"
+    )
+    scene = scenes[0]
+    assert scene["name"] == "map.png"
+    assert scene["img"] == "maps/map.png"
+    assert scene["width"] == 100
+    assert scene["height"] == 200
+    assert scene["grid"] == 75
+    assert scene["gridType"] == 1
+    assert scene["tags"] == ["dungeon", "map"]
+    assert scene["notes"] == "Check traps"
 
 
 def test_extract_images(tmp_path):
@@ -43,6 +57,15 @@ def test_extract_images(tmp_path):
     pdf = Path(__file__).parent / "data" / "sample.pdf"
     images = extract_images(pdf, tmp_path)
     assert len(images) == 0
+
+
+def test_extract_images_with_text(tmp_path):
+    """Text of each page is captured when requested."""
+    pdf = _generate_pdf(tmp_path / "text.pdf")
+    out = tmp_path / "out"
+    images = extract_images(pdf, out, include_text=True)
+    assert "text" in images[0]
+    assert "Label 1" in images[0]["text"]
 
 
 def test_extract_text():


### PR DESCRIPTION
## Summary
- capture optional page text during image extraction
- generate scene tags from text and add per-scene notes
- document new CLI flags and scene fields

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement PyMuPDF>=1.22.5)*
- `pylint pdf_parser.py tests/test_parser.py` *(fails: command not found: pylint)*
- `pytest` *(fails: 1 skipped in 0.02s)*

------
https://chatgpt.com/codex/tasks/task_e_68c54b54d0f88329adcd33a5c878891f