### PR TITLE
test: add coverage for metadata tags and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ Example:
 python pdf_parser.py file.pdf out --tags-from-text --note "GM only"
 ```
 
+## Testing
+
+Run the linter and test suite before submitting changes:
+
+```bash
+pylint pdf_parser.py
+pytest
+```
+
 ## Labeling and Folder Hierarchy
 
 - **Metadata-based labeling:** Alt text and bookmark titles label each image. Duplicate metadata points to the same JournalEntry so repeated images are not duplicated.

--- a/pdf_parser.py
+++ b/pdf_parser.py
@@ -141,7 +141,7 @@ def extract_images(
     }
 
     for page_index, page in enumerate(doc, start=1):
-        if page_range and not (page_range[0] <= page_index <= page_range[1]):
+        if page_range and not page_range[0] <= page_index <= page_range[1]:
             continue
         page_text = page.get_text("text") if include_text else None
         _process_page(
@@ -204,7 +204,9 @@ def build_foundry_scenes(images, grid_size=100, tags_from_text=False, note=None)
     return scenes
 
 
-if __name__ == "__main__":
+def main():
+    """Run the CLI interface."""
+
     import argparse
 
     parser = argparse.ArgumentParser(
@@ -230,11 +232,11 @@ if __name__ == "__main__":
     parser.add_argument("--note", help="Attach a note to every scene")
     args = parser.parse_args()
 
-    page_range = None
+    parsed_range = None
     if args.pages:
         try:
             start_str, end_str = args.pages.split("-", 1)
-            page_range = (int(start_str), int(end_str))
+            parsed_range = (int(start_str), int(end_str))
         except ValueError as exc:  # pragma: no cover - args parsing
             raise SystemExit("Invalid --pages format. Use START-END.") from exc
 
@@ -243,7 +245,7 @@ if __name__ == "__main__":
         args.out,
         use_metadata=not args.no_metadata,
         include_text=args.tags_from_text,
-        page_range=page_range,
+        page_range=parsed_range,
     )
     foundry_scenes = build_foundry_scenes(
         extracted_images,
@@ -260,3 +262,7 @@ if __name__ == "__main__":
     print(
         f"Extracted {len(extracted_images)} images. Scene definitions saved to {json_path}"
     )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,46 +1,22 @@
 """Integration tests for the pdf_parser CLI."""
 
-from pathlib import Path
 import json
+from pathlib import Path
 import subprocess
 import sys
 
-import pytest
+import pytest  # type: ignore  # pylint: disable=import-error
 
-try:
-    import fitz  # type: ignore  # pylint: disable=import-error
-except ImportError:  # pragma: no cover
-    fitz = None  # type: ignore
+sys.path.append(str(Path(__file__).resolve().parent))
+from utils import generate_pdf  # pylint: disable=wrong-import-position
 
 pytest.importorskip("fitz")
-
-import base64
-
-
-def _generate_pdf(path):
-    """Create a simple PDF with an image and caption on two pages."""
-
-    doc = fitz.open()
-    img_bytes = base64.b64decode(
-        b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PsLK"
-        b"FQAAAABJRU5ErkJggg==",
-    )
-    toc = []
-    for idx in range(2):
-        page = doc.new_page()
-        rect = fitz.Rect(20, 20, 120, 120)
-        page.insert_image(rect, stream=img_bytes)
-        page.insert_text(fitz.Point(20, 130), f"Label {idx + 1}")
-        toc.append([1, f"Section {idx + 1}", idx + 1])
-    doc.set_toc(toc)
-    doc.save(path)
-    return path
 
 
 def test_cli_integration(tmp_path):
     """Running the CLI extracts images and writes scenes.json."""
 
-    pdf = _generate_pdf(tmp_path / "cli.pdf")
+    pdf = generate_pdf(tmp_path / "cli.pdf")
     out = tmp_path / "out"
     cmd = [
         sys.executable,
@@ -59,3 +35,4 @@ def test_cli_integration(tmp_path):
     scenes = json.loads((out / "scenes.json").read_text(encoding="utf-8"))
     assert len(scenes["scenes"]) == 1
     assert "tags" in scenes["scenes"][0]
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,61 @@
+"""Integration tests for the pdf_parser CLI."""
+
+from pathlib import Path
+import json
+import subprocess
+import sys
+
+import pytest
+
+try:
+    import fitz  # type: ignore  # pylint: disable=import-error
+except ImportError:  # pragma: no cover
+    fitz = None  # type: ignore
+
+pytest.importorskip("fitz")
+
+import base64
+
+
+def _generate_pdf(path):
+    """Create a simple PDF with an image and caption on two pages."""
+
+    doc = fitz.open()
+    img_bytes = base64.b64decode(
+        b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PsLK"
+        b"FQAAAABJRU5ErkJggg==",
+    )
+    toc = []
+    for idx in range(2):
+        page = doc.new_page()
+        rect = fitz.Rect(20, 20, 120, 120)
+        page.insert_image(rect, stream=img_bytes)
+        page.insert_text(fitz.Point(20, 130), f"Label {idx + 1}")
+        toc.append([1, f"Section {idx + 1}", idx + 1])
+    doc.set_toc(toc)
+    doc.save(path)
+    return path
+
+
+def test_cli_integration(tmp_path):
+    """Running the CLI extracts images and writes scenes.json."""
+
+    pdf = _generate_pdf(tmp_path / "cli.pdf")
+    out = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve().parents[1] / "pdf_parser.py"),
+        str(pdf),
+        str(out),
+        "--pages",
+        "1-1",
+        "--tags-from-text",
+    ]
+    subprocess.run(cmd, check=True, capture_output=True)
+
+    images = list(out.glob("*.png")) + list(out.glob("*.jpg"))
+    assert len(images) == 1
+
+    scenes = json.loads((out / "scenes.json").read_text(encoding="utf-8"))
+    assert len(scenes["scenes"]) == 1
+    assert "tags" in scenes["scenes"][0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -110,3 +110,25 @@ def test_labels_and_hierarchy(tmp_path):
     images_nometa = extract_images(pdf, out2, use_metadata=False)
     assert images_nometa[0]["name"].startswith("p1_img1")
     assert images_nometa[0]["folders"] == []
+
+
+def test_metadata_tagging(tmp_path):
+    """Tags derive from folders and page text when requested."""
+
+    pdf = _generate_pdf(tmp_path / "tags.pdf")
+    out = tmp_path / "out"
+    images = extract_images(pdf, out, include_text=True)
+    scenes = build_foundry_scenes(images, tags_from_text=True)
+    tags = scenes[0]["tags"]
+    assert "section 1" in tags
+    assert "label" in tags
+
+
+def test_extract_images_page_range(tmp_path):
+    """Only pages within the provided range are processed."""
+
+    pdf = _generate_pdf(tmp_path / "range.pdf")
+    out = tmp_path / "out"
+    images = extract_images(pdf, out, page_range=(2, 2))
+    assert len(images) == 1
+    assert images[0]["page"] == 2

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,32 @@
+"""Test helpers."""
+
+import base64
+
+try:
+    import fitz  # type: ignore  # pylint: disable=import-error
+except ImportError:  # pragma: no cover
+    fitz = None  # type: ignore
+
+
+def generate_pdf(path):
+    """Create a simple two-page PDF with images and captions."""
+
+    if fitz is None:  # pragma: no cover - requires PyMuPDF
+        raise RuntimeError("PyMuPDF is required to generate sample PDFs")
+
+    doc = fitz.open()
+    img_bytes = base64.b64decode(
+        b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PsLK",
+        b"FQAAAABJRU5ErkJggg==",
+    )
+    toc = []
+    for idx in range(2):
+        page = doc.new_page()
+        rect = fitz.Rect(20, 20, 120, 120)
+        page.insert_image(rect, stream=img_bytes)
+        page.insert_text(fitz.Point(20, 130), f"Label {idx + 1}")
+        toc.append([1, f"Section {idx + 1}", idx + 1])
+    doc.set_toc(toc)
+    doc.save(path)
+    return path
+


### PR DESCRIPTION
## Summary
- add page range support and CLI flag
- test metadata tagging, fallback naming, page ranges, and CLI execution
- document lint and test commands in README

## Testing
- `pytest`
- `pylint pdf_parser.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c54c6787a483298403c8340d3ece8f