### PR TITLE
feat: package parser with CLI entry point

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ['3.10', '3.11']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           bash scripts/setup_codex_env.sh

--- a/README.md
+++ b/README.md
@@ -6,17 +6,23 @@ This repository contains a PDF parser that extracts embedded images and builds a
 
 - Python 3.10 or 3.11
 
+## Installation
+
+Install the project and its dependencies with `pip`:
+
+```bash
+pip install .
+```
+
 ## Usage
 
-1. Set up the Python environment:
-   ```bash
-   ./scripts/setup_codex_env.sh
-   ```
-2. Run the parser:
-   ```bash
-   python pdf_parser.py path/to/file.pdf output_dir
-   ```
-   Images are written to `output_dir`, and the directory will contain a `module.json` manifest and a `packs/images.json` compendium file ready for import into Foundry VTT.
+Run the parser from anywhere using the `pfpdf` command:
+
+```bash
+pfpdf path/to/file.pdf output_dir
+```
+
+Images are written to `output_dir`, and the directory will contain a `module.json` manifest and a `packs/images.json` compendium file ready for import into Foundry VTT.
 
 The parser uses [PyMuPDF](https://pymupdf.readthedocs.io/) to extract images, deduplicates them using PDF metadata, and can be extended with additional processing as needed. Optional flags provide extra metadata for the generated scenes:
 
@@ -26,7 +32,7 @@ The parser uses [PyMuPDF](https://pymupdf.readthedocs.io/) to extract images, de
 Example:
 
 ```bash
-python pdf_parser.py file.pdf out --tags-from-text --note "GM only"
+pfpdf file.pdf out --tags-from-text --note "GM only"
 ```
 
 ## Labeling and Folder Hierarchy

--- a/pdf_parser.py
+++ b/pdf_parser.py
@@ -195,11 +195,11 @@ def build_foundry_scenes(images, grid_size=100, tags_from_text=False, note=None)
     return scenes
 
 
-if __name__ == "__main__":
+def main(argv: List[str] | None = None) -> None:
+    """Command-line interface for :mod:`pdf_parser`."""
     import argparse
-
     parser = argparse.ArgumentParser(
-        description="Extract images and text from a PDF and prepare Foundry VTT scenes."
+        description="Extract images and text from a PDF and prepare Foundry VTT scenes.",
     )
     parser.add_argument("pdf", help="Path to the source PDF file")
     parser.add_argument("out", help="Directory to store extracted images and JSON")
@@ -215,7 +215,7 @@ if __name__ == "__main__":
         help="Generate scene tags from page text and bookmarks",
     )
     parser.add_argument("--note", help="Attach a note to every scene")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     extracted_images = extract_images(
         args.pdf,
@@ -238,3 +238,7 @@ if __name__ == "__main__":
     print(
         f"Extracted {len(extracted_images)} images. Scene definitions saved to {json_path}"
     )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/pdf_parser.py
+++ b/pdf_parser.py
@@ -1,5 +1,6 @@
 """Utilities for extracting PDF data and building Foundry VTT scenes."""
 
+import argparse
 import json
 import re
 from pathlib import Path
@@ -197,7 +198,6 @@ def build_foundry_scenes(images, grid_size=100, tags_from_text=False, note=None)
 
 def main(argv: List[str] | None = None) -> None:
     """Command-line interface for :mod:`pdf_parser`."""
-    import argparse
     parser = argparse.ArgumentParser(
         description="Extract images and text from a PDF and prepare Foundry VTT scenes.",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "pfpdf"
+version = "0.1.0"
+description = "PDF image extractor and Foundry VTT scene builder"
+readme = "README.md"
+requires-python = ">=3.10,<3.12"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+dependencies = [
+    "PyMuPDF>=1.22.5",
+]
+
+[project.scripts]
+pfpdf = "pdf_parser:main"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- package project with `pyproject.toml` and `pfpdf` console script
- wrap command line interface in a `main()` function
- document installation and usage via `pfpdf`
- restrict Python support to versions 3.10 and 3.11 and update CI

## Testing
- `bash scripts/setup_codex_env.sh` *(fails: Python 3.10 or 3.11 is required, found Python 3.12.10)*
- `pytest` *(fails: 1 skipped)*
- `pylint pdf_parser.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c54c616230832989ce40db81e086b1