### PR TITLE
fix: correct base64 decoding in test helper

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,4 +35,3 @@ def test_cli_integration(tmp_path):
     scenes = json.loads((out / "scenes.json").read_text(encoding="utf-8"))
     assert len(scenes["scenes"]) == 1
     assert "tags" in scenes["scenes"][0]
-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,13 +10,13 @@ pytest.importorskip("fitz")
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 sys.path.append(str(Path(__file__).resolve().parent))
 
+from utils import generate_pdf  # pylint: disable=wrong-import-position
+
 from pdf_parser import (  # pylint: disable=wrong-import-position
     build_foundry_scenes,
     extract_images,
     extract_text,
 )
-
-from utils import generate_pdf  # pylint: disable=wrong-import-position
 
 
 def test_build_foundry_scenes():
@@ -105,4 +105,3 @@ def test_extract_images_page_range(tmp_path):
     images = extract_images(pdf, out, page_range=(2, 2))
     assert len(images) == 1
     assert images[0]["page"] == 2
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,4 +35,3 @@ def generate_pdf(path):
     doc.set_toc(toc)
     doc.save(path)
     return path
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,9 +15,15 @@ def generate_pdf(path):
         raise RuntimeError("PyMuPDF is required to generate sample PDFs")
 
     doc = fitz.open()
+    # The image used in the generated PDF is stored as a Base64 string.  In the
+    # original version the string was split across two arguments to
+    # ``base64.b64decode``.  Python treats the second bytes object as the
+    # ``altchars`` parameter rather than part of the data, triggering an
+    # ``AssertionError`` when decoding.  Concatenating the pieces into a single
+    # bytes literal ensures the entire string is decoded correctly.
     img_bytes = base64.b64decode(
-        b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PsLK",
-        b"FQAAAABJRU5ErkJggg==",
+        b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PsLK"
+        b"FQAAAABJRU5ErkJggg=="
     )
     toc = []
     for idx in range(2):


### PR DESCRIPTION
## Summary
- ensure test PDF generation decodes base64 image correctly

## Testing
- `pytest -q`
- `pylint pdf_parser.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5506a06248329947067673a4cf9c1