### PR TITLE
feat: generate compendium entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ pfpdf path/to/file.pdf output_dir
 
 Images are written to `output_dir`, and the directory will contain a `module.json` manifest and a `packs/images.json` compendium file ready for import into Foundry VTT.
 
-The parser uses [PyMuPDF](https://pymupdf.readthedocs.io/) to extract images, deduplicates them using PDF metadata, and can be extended with additional processing as needed. Optional flags provide extra metadata for the generated scenes:
+The parser uses [PyMuPDF](https://pymupdf.readthedocs.io/) to extract images, deduplicates them using PDF metadata, and can be extended with additional processing as needed. Optional flags provide extra metadata for the generated entries:
 
-- `--tags-from-text` – include page text and bookmarks as tags on each scene.
-- `--note "Some note"` – attach a note to every generated scene.
+- `--tags-from-text` – include page text and bookmarks as tags on each entry.
+- `--note "Some note"` – attach a note to every generated entry.
 
 Example:
 
@@ -90,24 +90,6 @@ pytest
 ]
 ```
 
-`scenes.json`
-
-```json
-{
-  "scenes": [
-    {
-      "name": "map.png",
-      "img": "maps/map.png",
-      "width": 100,
-      "height": 200,
-      "grid": 75,
-      "gridType": 1,
-      "tags": ["dungeon", "map"],
-      "notes": "GM only"
-    }
-  ]
-}
-```
 
 ## Importing into Foundry VTT v13
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ pytest.importorskip("fitz")
 
 
 def test_cli_integration(tmp_path):
-    """Running the CLI extracts images and writes scenes.json."""
+    """Running the CLI extracts images and writes module & compendium files."""
 
     pdf = generate_pdf(tmp_path / "cli.pdf")
     out = tmp_path / "out"
@@ -32,6 +32,9 @@ def test_cli_integration(tmp_path):
     images = list(out.glob("*.png")) + list(out.glob("*.jpg"))
     assert len(images) == 1
 
-    scenes = json.loads((out / "scenes.json").read_text(encoding="utf-8"))
-    assert len(scenes["scenes"]) == 1
-    assert "tags" in scenes["scenes"][0]
+    module = json.loads((out / "module.json").read_text(encoding="utf-8"))
+    assert module["title"] == "cli"
+
+    pack = json.loads((out / "packs" / "images.json").read_text(encoding="utf-8"))
+    assert len(pack) == 1
+    assert "tags" in pack[0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,14 +13,14 @@ sys.path.append(str(Path(__file__).resolve().parent))
 from utils import generate_pdf  # pylint: disable=wrong-import-position
 
 from pdf_parser import (  # pylint: disable=wrong-import-position
-    build_foundry_scenes,
+    build_compendium_entries,
     extract_images,
     extract_text,
 )
 
 
-def test_build_foundry_scenes():
-    """Verify scenes include image metadata, tags and notes."""
+def test_build_compendium_entries():
+    """Verify entries include image references, tags and notes."""
     images = [
         {
             "name": "map.png",
@@ -31,18 +31,12 @@ def test_build_foundry_scenes():
             "folders": ["Dungeon"],
         }
     ]
-    scenes = build_foundry_scenes(
-        images, grid_size=75, tags_from_text=True, note="Check traps"
-    )
-    scene = scenes[0]
-    assert scene["name"] == "map.png"
-    assert scene["img"] == "maps/map.png"
-    assert scene["width"] == 100
-    assert scene["height"] == 200
-    assert scene["grid"] == 75
-    assert scene["gridType"] == 1
-    assert scene["tags"] == ["dungeon", "map"]
-    assert scene["notes"] == "Check traps"
+    entries = build_compendium_entries(images, tags_from_text=True, note="Check traps")
+    entry = entries[0]
+    assert entry["name"] == "map.png"
+    assert entry["pages"][0]["src"] == "maps/map.png"
+    assert entry["tags"] == ["dungeon", "map"]
+    assert entry["notes"] == "Check traps"
 
 
 def test_extract_images(tmp_path):
@@ -91,8 +85,8 @@ def test_metadata_tagging(tmp_path):
     pdf = generate_pdf(tmp_path / "tags.pdf")
     out = tmp_path / "out"
     images = extract_images(pdf, out, include_text=True)
-    scenes = build_foundry_scenes(images, tags_from_text=True)
-    tags = scenes[0]["tags"]
+    entries = build_compendium_entries(images, tags_from_text=True)
+    tags = entries[0]["tags"]
     assert "section 1" in tags
     assert "label" in tags
 


### PR DESCRIPTION
## Summary
- build journal entry compendiums instead of Foundry scenes
- save module.json and packs/images.json from CLI
- test compendium generation and CLI outputs

## Testing
- `pylint pdf_parser.py tests/test_parser.py tests/test_cli.py` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c554433fb4832980d6d355be590e38