### PR TITLE
feat: add module metadata options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,19 @@ The parser uses [PyMuPDF](https://pymupdf.readthedocs.io/) to extract images, de
 
 - `--tags-from-text` – include page text and bookmarks as tags on each scene.
 - `--note "Some note"` – attach a note to every generated scene.
+- `--module-id` – set the module identifier used in `module.json`.
+- `--title` – set a custom module title instead of the PDF filename.
 
 Example:
 
 ```bash
-pfpdf file.pdf out --tags-from-text --note "GM only"
+pfpdf file.pdf out --tags-from-text --note "GM only" --module-id mymod --title "My Module"
 ```
+
+Environment variables can override the corresponding CLI flags when present:
+
+- `PFPDF_MODULE_ID` – overrides `--module-id`.
+- `PFPDF_TITLE` – overrides `--title`.
 
 ## Testing
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Integration tests for the pdf_parser CLI."""
 
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -26,6 +27,10 @@ def test_cli_integration(tmp_path):
         "--pages",
         "1-1",
         "--tags-from-text",
+        "--module-id",
+        "testmod",
+        "--title",
+        "Test Title",
     ]
     subprocess.run(cmd, check=True, capture_output=True)
 
@@ -35,3 +40,37 @@ def test_cli_integration(tmp_path):
     scenes = json.loads((out / "scenes.json").read_text(encoding="utf-8"))
     assert len(scenes["scenes"]) == 1
     assert "tags" in scenes["scenes"][0]
+
+    module = json.loads((out / "module.json").read_text(encoding="utf-8"))
+    assert module["name"] == "testmod"
+    assert module["title"] == "Test Title"
+
+    compendium = json.loads(
+        (out / "packs" / "images.json").read_text(encoding="utf-8")
+    )
+    assert len(compendium) == 1
+
+
+def test_env_overrides(tmp_path):
+    """Environment variables override CLI flags."""
+
+    pdf = generate_pdf(tmp_path / "env.pdf")
+    out = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve().parents[1] / "pdf_parser.py"),
+        str(pdf),
+        str(out),
+        "--module-id",
+        "cliid",
+        "--title",
+        "Cli Title",
+    ]
+    env = os.environ.copy()
+    env["PFPDF_MODULE_ID"] = "envmod"
+    env["PFPDF_TITLE"] = "Env Title"
+    subprocess.run(cmd, check=True, capture_output=True, env=env)
+
+    module = json.loads((out / "module.json").read_text(encoding="utf-8"))
+    assert module["name"] == "envmod"
+    assert module["title"] == "Env Title"


### PR DESCRIPTION
## Summary
- allow setting Foundry module ID and title via CLI or env vars
- include module metadata in generated compendium and manifest
- test CLI overrides and document new flags

## Testing
- `pytest`
- `pylint pdf_parser.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5544c68108329a55c122f18f4c873