### PR TITLE
test: add hierarchy tests for CLI and compendium

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,3 +77,28 @@ def test_env_overrides(tmp_path):
     flags = pack[0]["flags"]["pfpdf"]
     assert flags["module_id"] == "env_id"
     assert flags["title"] == "Env Title"
+
+
+def test_cli_hierarchy(tmp_path):
+    """CLI populates module and compendium with hierarchy data."""
+
+    pdf = generate_pdf(tmp_path / "hier.pdf")
+    out = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve().parents[1] / "pdf_parser.py"),
+        str(pdf),
+        str(out),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True)
+
+    module = json.loads((out / "module.json").read_text(encoding="utf-8"))
+    assert module["name"] == "hier"
+    assert module["title"] == "hier"
+    assert module["packs"][0]["type"] == "JournalEntry"
+
+    pack = json.loads((out / "packs" / "images.json").read_text(encoding="utf-8"))
+    assert len(pack) == 2
+    assert pack[0]["name"].startswith("label_1")
+    assert pack[0]["folder"] == "Section 1/Subsection 1.1"
+    assert pack[1]["folder"] == "Section 2"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -70,13 +70,25 @@ def test_labels_and_hierarchy(tmp_path):
     out = tmp_path / "out"
     images = extract_images(pdf, out)
     assert images[0]["name"].startswith("label_1")
-    assert images[0]["folders"] == ["Section 1"]
+    assert images[0]["folders"] == ["Section 1", "Subsection 1.1"]
     assert images[1]["folders"] == ["Section 2"]
 
     out2 = tmp_path / "out2"
     images_nometa = extract_images(pdf, out2, use_metadata=False)
     assert images_nometa[0]["name"].startswith("p1_img1")
     assert images_nometa[0]["folders"] == []
+
+
+def test_compendium_folder_labels(tmp_path):
+    """Compendium entries include folders and metadata-based names."""
+
+    pdf = generate_pdf(tmp_path / "compendium.pdf")
+    out = tmp_path / "out"
+    images = extract_images(pdf, out)
+    entries = build_compendium_entries(images)
+    assert entries[0]["name"].startswith("label_1")
+    assert entries[0]["folder"] == "Section 1/Subsection 1.1"
+    assert entries[1]["folder"] == "Section 2"
 
 
 def test_metadata_tagging(tmp_path):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,7 +9,7 @@ except ImportError:  # pragma: no cover
 
 
 def generate_pdf(path):
-    """Create a simple two-page PDF with images and captions."""
+    """Create a two-page PDF with images, captions and nested bookmarks."""
 
     if fitz is None:  # pragma: no cover - requires PyMuPDF
         raise RuntimeError("PyMuPDF is required to generate sample PDFs")
@@ -25,13 +25,18 @@ def generate_pdf(path):
         b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PsLK"
         b"FQAAAABJRU5ErkJggg=="
     )
-    toc = []
     for idx in range(2):
         page = doc.new_page()
         rect = fitz.Rect(20, 20, 120, 120)
         page.insert_image(rect, stream=img_bytes)
         page.insert_text(fitz.Point(20, 130), f"Label {idx + 1}")
-        toc.append([1, f"Section {idx + 1}", idx + 1])
-    doc.set_toc(toc)
+
+    doc.set_toc(
+        [
+            [1, "Section 1", 1],
+            [2, "Subsection 1.1", 1],
+            [1, "Section 2", 2],
+        ]
+    )
     doc.save(path)
     return path


### PR DESCRIPTION
## Summary
- generate sample PDFs with nested bookmarks
- add unit test validating folder paths and metadata labels
- verify CLI outputs expected module and compendium fields

## Testing
- `pytest -q`
- `pylint pdf_parser.py tests/utils.py tests/test_cli.py tests/test_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5592dbc08832982c9a5eb38d12675