### PR TITLE
feat: deduplicate extracted images

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,7 +98,6 @@ def test_cli_hierarchy(tmp_path):
     assert module["packs"][0]["type"] == "JournalEntry"
 
     pack = json.loads((out / "packs" / "images.json").read_text(encoding="utf-8"))
-    assert len(pack) == 2
+    assert len(pack) == 1
     assert pack[0]["name"].startswith("label_1")
     assert pack[0]["folder"] == "Section 1/Subsection 1.1"
-    assert pack[1]["folder"] == "Section 2"


### PR DESCRIPTION
## Summary
- avoid writing duplicate images by tracking xrefs and checksums
- map repeated labels to the first saved image
- ensure tests cover duplicate handling

## Testing
- `pylint pdf_parser.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c55a2e5eec832991a51deed77efc7e