### PR TITLE
fix: close PyMuPDF resources

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,29 +14,27 @@ def generate_pdf(path):
     if fitz is None:  # pragma: no cover - requires PyMuPDF
         raise RuntimeError("PyMuPDF is required to generate sample PDFs")
 
-    doc = fitz.open()
-    # The image used in the generated PDF is stored as a Base64 string.  In the
-    # original version the string was split across two arguments to
-    # ``base64.b64decode``.  Python treats the second bytes object as the
-    # ``altchars`` parameter rather than part of the data, triggering an
-    # ``AssertionError`` when decoding.  Concatenating the pieces into a single
-    # bytes literal ensures the entire string is decoded correctly.
-    img_bytes = base64.b64decode(
-        b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PsLK"
-        b"FQAAAABJRU5ErkJggg=="
-    )
-    for idx in range(2):
-        page = doc.new_page()
-        rect = fitz.Rect(20, 20, 120, 120)
-        page.insert_image(rect, stream=img_bytes)
-        page.insert_text(fitz.Point(20, 130), f"Label {idx + 1}")
+    with fitz.open() as doc:
+        # The image used in the generated PDF is stored as a Base64 string.  In the
+        # original version the string was split across two arguments to
+        # ``base64.b64decode``.  Python treats the second bytes object as the
+        # ``altchars`` parameter rather than part of the data, triggering an
+        # ``AssertionError`` when decoding.  Concatenating the pieces into a single
+        # bytes literal ensures the entire string is decoded correctly.
+        img_bytes = base64.b64decode(
+            b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PsLK"
+            b"FQAAAABJRU5ErkJggg=="
+        )
+        for idx in range(2):
+            page = doc.new_page()
+            rect = fitz.Rect(20, 20, 120, 120)
+            page.insert_image(rect, stream=img_bytes)
+            page.insert_text(fitz.Point(20, 130), f"Label {idx + 1}")
 
-    doc.set_toc(
-        [
+        doc.set_toc([
             [1, "Section 1", 1],
             [2, "Subsection 1.1", 1],
             [1, "Section 2", 2],
-        ]
-    )
-    doc.save(path)
+        ])
+        doc.save(path)
     return path


### PR DESCRIPTION
## Summary
- ensure Pixmap objects are closed to avoid leaks
- use context managers for opening PDFs in extraction helpers
- wrap PDF generator in tests with context manager

## Testing
- `python -m pytest`
- `pylint pdf_parser.py tests`


------
https://chatgpt.com/codex/tasks/task_e_68c55d404e4c83299b003c6855c51cc3