### PR TITLE
fix: validate page range order

### DIFF
--- a/pdf_parser.py
+++ b/pdf_parser.py
@@ -283,9 +283,13 @@ def main(argv: List[str] | None = None) -> None:
     parsed_range = None
     if args.pages:
         try:
-            parsed_range = tuple(map(int, args.pages.split("-", 1)))
+            start_str, end_str = args.pages.split("-", 1)
+            start, end = int(start_str), int(end_str)
         except ValueError as exc:  # pragma: no cover - args parsing
             raise SystemExit("Invalid --pages format. Use START-END.") from exc
+        if start > end:
+            raise SystemExit("--pages start must be <= end.")
+        parsed_range = (start, end)
 
     extracted_images, _ = extract_images(
         args.pdf,

--- a/pdf_parser.py
+++ b/pdf_parser.py
@@ -280,23 +280,23 @@ def main(argv: List[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
-    parsed_range = None
+    page_range = None
     if args.pages:
         try:
-            start_str, end_str = args.pages.split("-", 1)
-            start, end = int(start_str), int(end_str)
+            page_range = tuple(map(int, args.pages.split("-", 1)))
+            if len(page_range) != 2:
+                raise ValueError
         except ValueError as exc:  # pragma: no cover - args parsing
             raise SystemExit("Invalid --pages format. Use START-END.") from exc
-        if start > end:
+        if page_range[0] > page_range[1]:
             raise SystemExit("--pages start must be <= end.")
-        parsed_range = (start, end)
 
     extracted_images, _ = extract_images(
         args.pdf,
         args.out,
         use_metadata=not args.no_metadata,
         include_text=args.tags_from_text,
-        page_range=parsed_range,
+        page_range=page_range,
     )
 
     module_id = os.getenv(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,3 +152,11 @@ def test_invalid_pages_range():
 
     with pytest.raises(SystemExit):
         pdf_parser.main(["dummy.pdf", "out", "--pages", "invalid"])
+
+
+@pytest.mark.parametrize("page_spec", ["5-2", "1-", "3"])
+def test_reversed_or_malformed_pages_range(page_spec):
+    """Reversed or malformed page ranges exit with an error."""
+
+    with pytest.raises(SystemExit):
+        pdf_parser.main(["dummy.pdf", "out", "--pages", page_spec])


### PR DESCRIPTION
## Summary
- validate --pages start <= end and error out otherwise
- test invalid CLI page ranges

## Testing
- `pytest`
- `pylint pdf_parser.py tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68c560b672f88329915b29e15e594e92