### PR TITLE
test: cover CLI metadata and notes flags

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -122,7 +122,13 @@ def test_cli_no_metadata(tmp_path):
     ]
     subprocess.run(cmd, check=True, capture_output=True)
 
-    pack = json.loads((out / "packs" / "images.json").read_text(encoding="utf-8"))
+    images = list(out.glob("*.png")) + list(out.glob("*.jpg"))
+    assert len(images) == 1
+    assert images[0].name.startswith("p1_img1")
+
+    pack_dir = out / "packs"
+    pack = json.loads((pack_dir / "images.json").read_text(encoding="utf-8"))
+    assert list(pack_dir.iterdir()) == [pack_dir / "images.json"]
     entry = pack[0]
     assert entry["name"].startswith("p1_img1")
     assert "folder" not in entry
@@ -151,5 +157,6 @@ def test_cli_note(tmp_path):
 def test_invalid_pages_range():
     """An invalid page range causes the CLI to exit with an error."""
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as exc:
         pdf_parser.main(["dummy.pdf", "out", "--pages", "invalid"])
+    assert exc.value.code != 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -159,11 +159,12 @@ def test_invalid_pages_range():
 
     with pytest.raises(SystemExit) as exc:
         pdf_parser.main(["dummy.pdf", "out", "--pages", "invalid"])
-
+    assert exc.value.code != 0
 
 @pytest.mark.parametrize("page_spec", ["5-2", "1-", "3"])
 def test_reversed_or_malformed_pages_range(page_spec):
     """Reversed or malformed page ranges exit with an error."""
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as exc:
         pdf_parser.main(["dummy.pdf", "out", "--pages", page_spec])
+    assert exc.value.code != 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -159,7 +159,6 @@ def test_invalid_pages_range():
 
     with pytest.raises(SystemExit) as exc:
         pdf_parser.main(["dummy.pdf", "out", "--pages", "invalid"])
-    assert exc.value.code != 0
 
 
 @pytest.mark.parametrize("page_spec", ["5-2", "1-", "3"])
@@ -168,4 +167,3 @@ def test_reversed_or_malformed_pages_range(page_spec):
 
     with pytest.raises(SystemExit):
         pdf_parser.main(["dummy.pdf", "out", "--pages", page_spec])
-    assert exc.value.code != 0


### PR DESCRIPTION
## Summary
- expand no-metadata test to verify fallback naming and empty packs folder
- ensure notes flag writes note to pack metadata
- assert invalid page range terminates CLI with an error

## Testing
- `pylint pdf_parser.py tests/test_cli.py tests/test_parser.py tests/utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c562fece288329bebfe7bbda2ffc28